### PR TITLE
[Feature implementation] Set up CD workflow for automated deployment to Google Cloud Run

### DIFF
--- a/.github/workflows/deploy_cloud_run.yml
+++ b/.github/workflows/deploy_cloud_run.yml
@@ -48,6 +48,9 @@ jobs:
           workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
           service_account: '${{ env.SERVICE_ACCOUNT }}'
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Login to Artifact Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Related issues

* #16

### What's done

* Fixed the deployment error.
  * The error "Cache export is not supported for the docker driver" occurs because the default Docker driver used by GitHub Actions doesn't support exporting caches (required for cache-to: type=gha).
  * To fix this, we need to use the docker-container driver, which is provided by the docker/setup-buildx-action.

### Unit Test

* 

### Notes

* 
