### PR TITLE
[Bug report] Inconsistent naming convention between Group ID and Artifact ID in GitHub Package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Replace `LATEST_VERSION` with the latest version number you see in the [Packages
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("org.fog_rock:fr-line-agent-core:LATEST_VERSION")
+    implementation("org.fog-rock:fr-line-agent-core:LATEST_VERSION")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,6 @@ plugins {
 }
 
 allprojects {
-    group = "org.fog_rock"
+    group = "org.fog-rock"
     version = "1.0.0-alpha.1"
 }


### PR DESCRIPTION
### Pre-merge Checklist

- [x] Assignees are set.
- [x] Labels are set.
- [x] Milestone is set.

---

## Related issues

* #40 

### Cause of bug

* The project's group ID was incorrectly configured as `org.fog_rock`, leading to an inconsistent package name.

### What's fixed

* Updated the project's group ID to `org.fog-rock` for consistency in package naming.

### Unit Test

* This bug fix does not affect the app build.

### Notes

* 
