### PR TITLE
[Bug report] MockSecretProvider does not support keys other than the one defined by default.

### DIFF
--- a/fr-line-agent-core/src/main/kotlin/org/fog_rock/frlineagent/core/infrastructure/mock/MockSecretProvider.kt
+++ b/fr-line-agent-core/src/main/kotlin/org/fog_rock/frlineagent/core/infrastructure/mock/MockSecretProvider.kt
@@ -18,13 +18,9 @@ package org.fog_rock.frlineagent.core.infrastructure.mock
 
 import org.fog_rock.frlineagent.core.domain.repository.SecretProvider
 
-internal class MockSecretProvider : SecretProvider {
-    private val secrets = mapOf(
-        "LINE_CHANNEL_ACCESS_TOKEN" to "mock_line_channel_access_token",
-        "LINE_CHANNEL_SECRET" to "mock_line_channel_secret",
-        "SPREADSHEET_ID" to "mock_spreadsheet_id",
-        "GOOGLE_CREDENTIALS_JSON" to "{}"
-    )
+internal class MockSecretProvider(
+    private val secrets: Map<String, String> = emptyMap()
+) : SecretProvider {
 
     override fun getSecret(key: String): String =
         secrets[key] ?: throw IllegalArgumentException("Secret key `$key` not found in mock.")

--- a/fr-line-agent-core/src/main/kotlin/org/fog_rock/frlineagent/core/plugin/FRLineAgent.kt
+++ b/fr-line-agent-core/src/main/kotlin/org/fog_rock/frlineagent/core/plugin/FRLineAgent.kt
@@ -49,7 +49,15 @@ val FRLineAgent = createApplicationPlugin(
                     }
                     GoogleSecretProvider(projectNumber)
                 }
-                ProviderMode.MOCK -> MockSecretProvider()
+                ProviderMode.MOCK -> {
+                    val mockSecrets = mapOf(
+                        "LINE_CHANNEL_ACCESS_TOKEN" to "mock_line_channel_access_token",
+                        "LINE_CHANNEL_SECRET" to "mock_line_channel_secret",
+                        "SPREADSHEET_ID" to "mock_spreadsheet_id",
+                        "GOOGLE_CREDENTIALS_JSON" to "{}"
+                    )
+                    MockSecretProvider(mockSecrets)
+                }
             }
         }
         single<LineClient> {

--- a/fr-line-agent-core/src/test/kotlin/org/fog_rock/frlineagent/core/infrastructure/mock/MockSecretProviderTest.kt
+++ b/fr-line-agent-core/src/test/kotlin/org/fog_rock/frlineagent/core/infrastructure/mock/MockSecretProviderTest.kt
@@ -22,18 +22,29 @@ import org.junit.jupiter.api.assertThrows
 
 class MockSecretProviderTest {
 
-    private val secretProvider = MockSecretProvider()
-
     @Test
     fun testGetSecret_success() {
-        assertEquals("mock_line_channel_access_token", secretProvider.getSecret("LINE_CHANNEL_ACCESS_TOKEN"))
-        assertEquals("mock_line_channel_secret", secretProvider.getSecret("LINE_CHANNEL_SECRET"))
-        assertEquals("mock_spreadsheet_id", secretProvider.getSecret("SPREADSHEET_ID"))
-        assertEquals("{}", secretProvider.getSecret("GOOGLE_CREDENTIALS_JSON"))
+        val secrets = mapOf(
+            "LINE_CHANNEL_ACCESS_TOKEN" to "custom_line_channel_access_token",
+            "CUSTOM_KEY" to "custom_value"
+        )
+        val secretProvider = MockSecretProvider(secrets)
+
+        assertEquals("custom_line_channel_access_token", secretProvider.getSecret("LINE_CHANNEL_ACCESS_TOKEN"))
+        assertEquals("custom_value", secretProvider.getSecret("CUSTOM_KEY"))
     }
 
     @Test
     fun testGetSecret_failure() {
+        // Test with empty secrets.
+        val emptySecretProvider = MockSecretProvider()
+        assertThrows<IllegalArgumentException> {
+            emptySecretProvider.getSecret("UNKNOWN_KEY")
+        }
+
+        // Test with non-empty secrets.
+        val secrets = mapOf("EXISTING_KEY" to "EXISTING_VALUE")
+        val secretProvider = MockSecretProvider(secrets)
         assertThrows<IllegalArgumentException> {
             secretProvider.getSecret("UNKNOWN_KEY")
         }


### PR DESCRIPTION
### Pre-merge Checklist

- [x] Assignees are set.
- [x] Labels are set.
- [x] Milestone is set.

---

## Related issues

* #42 

### Cause of bug

* Omissions in considerations regarding multi-module support.

### What's fixed

* Refactored MockSecretProvider to remove hardcoded secrets and accept them via the constructor.
* The default mock secrets are now defined and injected by the FRLineAgent plugin, allowing for better configuration.

### Unit Test

* Passed all test codes.

### Notes

* 
